### PR TITLE
Fix Over-under-flow examples for remix 0.5.1

### DIFF
--- a/Over-under-flow/problem.sol
+++ b/Over-under-flow/problem.sol
@@ -1,15 +1,15 @@
-pragma solidity ^0.4.20;
+pragma solidity 0.5.1;
 
 contract C {
 
     // (2**256 - 1) + 1 = 0
-    function overflow() constant returns (uint256 _overflow) {
+    function overflow() public pure returns (uint256 _overflow) {
         uint256 max = 2**256 -1;
         return max + 1;
     }
 
     // 0 - 1 = 2**256 - 1
-    function underflow() constant returns (uint256 _underflow) {
+    function underflow() public pure returns (uint256 _underflow) {
         uint256 min = 0;
         return min - 1;
     }

--- a/Over-under-flow/solution.sol
+++ b/Over-under-flow/solution.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.20;
+pragma solidity 0.5.1;
 
 library SafeMath {
 
@@ -51,13 +51,13 @@ contract C {
     using SafeMath for uint256;
 
     // (2**256 - 1) + 1 = 0
-    function overflow() constant returns (uint256 _overflow) {
+    function overflow() public pure returns (uint256 _overflow) {
         uint256 max = 2**256 -1;
         return max.add(1);
     }
 
     // 0 - 1 = 2**256 - 1
-    function underflow() constant returns (uint256 _underflow) {
+    function underflow() public pure returns (uint256 _underflow) {
         uint256 min = 0;
         return min.sub(1);
     }


### PR DESCRIPTION
The examples show some errors with the actual remix version. Fixed.

Note: in all your examples I've seen so far you use 0.5.1, so for consistency this example shpuld be based on 0.5.1 too.